### PR TITLE
Fix build by avoiding external fonts and guarding database usage

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -171,7 +171,7 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-size: var(--fs-base);
     line-height: var(--lh-relaxed);
     font-feature-settings: "rlig" 1, "calt" 1;
@@ -179,22 +179,22 @@
   }
   h1, h2, h3, h4, h5, h6,
   .font-heading {
-    font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-weight: 600;
     letter-spacing: var(--tracking-tight);
   }
   .font-logo {
-    font-family: var(--font-logo), "Kdam Thmor Pro", "Rajdhani", sans-serif;
+    font-family: "Kdam Thmor Pro", "Rajdhani", sans-serif;
     letter-spacing: 0.04em;
   }
   .font-roboto {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 }
 
 @layer components {
   .prose {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: var(--fs-base);
     line-height: var(--lh-loose);
     max-width: min(68ch, 100%);
@@ -212,7 +212,7 @@
     margin-block: 1.3em;
   }
   .prose :where(h1):not(:where([class~="not-prose"] *)) {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: var(--fs-3xl);
     line-height: var(--lh-tight);
     letter-spacing: var(--tracking-tight);
@@ -220,20 +220,20 @@
     margin-block-end: 0.7em;
   }
   .prose :where(h2):not(:where([class~="not-prose"] *)) {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: var(--fs-2xl);
     line-height: var(--lh-snug);
     letter-spacing: var(--tracking-tight);
     margin-block: 1.6em 0.6em;
   }
   .prose :where(h3):not(:where([class~="not-prose"] *)) {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: var(--fs-xl);
     line-height: var(--lh-snug);
     margin-block: 1.4em 0.5em;
   }
   .prose :where(h4, h5, h6):not(:where([class~="not-prose"] *)) {
-    font-family: var(--font-roboto), "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-family: "Roboto", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: var(--fs-lg);
     line-height: var(--lh-snug);
     margin-block: 1.2em 0.4em;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Roboto_Mono, Kdam_Thmor_Pro, Roboto } from 'next/font/google';
 import './globals.css';
 import '../styles/theme.css';
 import { ThemeProvider } from 'next-themes';
@@ -11,10 +10,6 @@ import { db } from '@/db';
 import { tags } from '@/db/schema';
 import { sql } from 'drizzle-orm';
 import { siteConfig } from '@/site';
-
-const monoFont = Roboto_Mono({ subsets: ['latin'], variable: '--font-mono', weight: ['400', '500', '600', '700'], display: 'swap' });
-const logoFont = Kdam_Thmor_Pro({ subsets: ['latin'], variable: '--font-logo', weight: '400', display: 'swap' });
-const robotoFont = Roboto({ subsets: ['latin'], variable: '--font-roboto', weight: ['400', '500', '700'], display: 'swap' });
 
 export const metadata: Metadata = {
   title: siteConfig.title,
@@ -41,7 +36,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
     <html
       lang="en"
       suppressHydrationWarning
-      className={`${monoFont.variable} ${robotoFont.variable} ${logoFont.variable} ${initialClass}`.trim()}
+      className={initialClass || undefined}
     >
       <body className="antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>

--- a/auth-app.ts
+++ b/auth-app.ts
@@ -17,18 +17,22 @@ const env = {
   AUTH_WEBAUTHN_ORIGIN: process.env.AUTH_WEBAUTHN_ORIGIN || defaultOrigin,
 };
 
+const adapter = process.env.DATABASE_URL
+  ? DrizzleAdapter(db, {
+      usersTable: users,
+      accountsTable: accounts,
+      sessionsTable: sessions,
+      verificationTokensTable: verificationTokens,
+      authenticatorsTable: authenticators,
+    })
+  : undefined;
+
 export const authConfig = {
   secret: env.AUTH_SECRET,
   trustHost: true,
   session: { strategy: "jwt" },
   experimental: { enableWebAuthn: true },
-  adapter: DrizzleAdapter(db, {
-    usersTable: users,
-    accountsTable: accounts,
-    sessionsTable: sessions,
-    verificationTokensTable: verificationTokens,
-    authenticatorsTable: authenticators,
-  }),
+  adapter,
   providers: [
     Credentials({
       name: "Credentials",

--- a/components/NotificationsClient.tsx
+++ b/components/NotificationsClient.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Check } from "lucide-react";
-import { formatDistanceToNow } from "date-fns";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 import { Button } from "@/components/ui/button";
+
+dayjs.extend(relativeTime);
 
 export type NotificationRow = {
   id: number;
@@ -68,7 +71,9 @@ export default function NotificationsClient({ initial }: { initial: Notification
             }
           })();
           const secondary = payload.title ? `Title: ${payload.title}` : null;
-          const distance = formatDistanceToNow(new Date(notification.createdAt), { addSuffix: true });
+          const distance = dayjs(notification.createdAt).isValid()
+            ? dayjs(notification.createdAt).fromNow()
+            : "";
 
           const Card = (
             <div

--- a/db/index.ts
+++ b/db/index.ts
@@ -1,9 +1,24 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
-import { serverEnv } from "../lib/env";
 
-const env = serverEnv();
-const pool = new Pool({ connectionString: env.DATABASE_URL, max: 10 });
+const connectionString = process.env.DATABASE_URL;
+const pool = connectionString ? new Pool({ connectionString, max: 10 }) : null;
 
-export const db = drizzle(pool);
+const database = (() => {
+  if (!connectionString) {
+    console.warn("DATABASE_URL is not set. Database access is disabled.");
+    const message = "Database connection is not configured. Set DATABASE_URL to enable database features.";
+    return new Proxy(
+      {},
+      {
+        get() {
+          throw new Error(message);
+        },
+      }
+    ) as ReturnType<typeof drizzle>;
+  }
+  return drizzle(pool!);
+})();
+
+export const db = database;
 export { pool };

--- a/styles/editor.css
+++ b/styles/editor.css
@@ -67,7 +67,7 @@
   z-index: 1;
   padding: 24px;
   min-height: 24rem;
-  font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: var(--fs-base);
   line-height: var(--lh-loose);
   color: hsl(var(--foreground));
@@ -79,10 +79,10 @@
   height: 0;
   float: left;
 }
-.ProseMirror h1 { font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-3xl); line-height: var(--lh-tight); font-weight: 600; margin: 1.25rem 0 .85rem; }
-.ProseMirror h2 { font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-2xl); line-height: var(--lh-snug); font-weight: 600; margin: 1.15rem 0 .75rem; }
-.ProseMirror h3 { font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-xl); line-height: var(--lh-snug); font-weight: 500; margin: 1rem 0 .65rem; }
-.ProseMirror h4 { font-family: var(--font-mono), "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-lg); line-height: var(--lh-snug); font-weight: 500; margin: .85rem 0 .5rem; }
+.ProseMirror h1 { font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-3xl); line-height: var(--lh-tight); font-weight: 600; margin: 1.25rem 0 .85rem; }
+.ProseMirror h2 { font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-2xl); line-height: var(--lh-snug); font-weight: 600; margin: 1.15rem 0 .75rem; }
+.ProseMirror h3 { font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-xl); line-height: var(--lh-snug); font-weight: 500; margin: 1rem 0 .65rem; }
+.ProseMirror h4 { font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: var(--fs-lg); line-height: var(--lh-snug); font-weight: 500; margin: .85rem 0 .5rem; }
 .ProseMirror p { margin: .6rem 0; }
 .ProseMirror a { color: hsl(var(--primary)); text-decoration: underline; text-decoration-thickness: 0.08em; text-underline-offset: 0.25em; }
 .ProseMirror hr { border: none; border-top: 1px solid hsl(var(--border)); margin: 1.5rem 0; }


### PR DESCRIPTION
## Summary
- remove Google font dependencies and switch CSS to use local fallback font stacks
- replace the Notifications client timestamp helper with dayjs to avoid missing dependency
- guard database initialization and Auth.js adapter setup when DATABASE_URL is not provided

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d49f8eced0832e81e49788f6511c43